### PR TITLE
Fix error message to report correct maximum line number

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -16,7 +16,7 @@ module.exports = class NoLongMethods
     if lastLine - firstLine > max
       @errors.push api.createError
         context: name
-        message: "Functions must not be longer than #{ @rule.value } lines"
+        message: "Functions must not be longer than #{max} lines"
         lineNumber: firstLine
         lineNumberEnd: lastLine
 


### PR DESCRIPTION
Previously, the error message would always be "Functions must not be longer than 20 lines," even if the user had configured their maximum line number differently. This pull request fixes the error message to report the user-configured number.
